### PR TITLE
fix if ERA5.1 data missing

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -8,6 +8,15 @@ What's New
 
     import pyremo
 
+
+v0.8.1 (10 April 2025)
+----------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+- Use ERA5 data instead of ERA5.1 if it is missing (:pull:`230`).
+
 v0.8.0 (9 April 2025)
 ---------------------
 


### PR DESCRIPTION
This pull request includes several changes to the `pyremo/preproc/era5.py` file to improve file handling and ensure the correct era ID is used when files are not found.